### PR TITLE
Add a Conversation handler to sign up to Leetcode mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 .env
 data
+
+# everything i want to store locally
+*.local.*

--- a/constants.py
+++ b/constants.py
@@ -84,3 +84,10 @@ leetcode_course_id: int = 7
 sre_course_id: int = 8
 
 id_to_course = {7: "Leetcode", 8: "SRE"}
+
+leetcode_register_ask_timeslots = ("В какое время можешь созвониться? Время указано по Москве."
+                                   "\n\nВыбери хотя бы три слота.")
+
+
+leetcode_register_timeslots = ['Пятница 21:00', 'Суббота 13:00', 'Суббота 21:00', 'Воскресенье 13:00',
+                               'Воскресенье 21:00']

--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from sqlalchemy.orm import Session
 
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, User
 from telegram.ext import CommandHandler, ContextTypes, ConversationHandler, MessageHandler, filters
 
 import constants
@@ -93,12 +93,15 @@ async def start_echo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 
 @is_sre_admin
-async def echo_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def echo_message(update: Update, context: ContextTypes.DEFAULT_TYPE, reply_markup: InlineKeyboardMarkup = None)\
+        -> int:
     logging.info(f"echo_message handler triggered by {helpers.get_user(update)}")
     await context.bot.send_message(
         chat_id=update.effective_chat.id,
         text=update.message.text,
-        entities=update.message.entities
+        entities=update.message.entities,
+        reply_markup=reply_markup,
+        parse_mode="HTML"
     )
     return ConversationHandler.END
 
@@ -134,7 +137,8 @@ async def start_broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
 
 @is_admin
-async def broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE, reply_markup: InlineKeyboardMarkup = None)\
+        -> int:
     logging.info(f"broadcast handler triggered by {helpers.get_user(update)}")
 
     with Session(engine) as session:
@@ -148,7 +152,9 @@ async def broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
             await context.bot.send_message(
                 chat_id=user.tg_id,
                 text=update.message.text,
-                entities=update.message.entities
+                entities=update.message.entities,
+                reply_markup=reply_markup,
+                parse_mode="HTML"
             )
             successful_count += 1
         except Exception as e:
@@ -177,7 +183,8 @@ broadcast_conv_handler = ConversationHandler(
 )
 
 
-async def do_broadcast_course(update: Update, context: ContextTypes.DEFAULT_TYPE, course_id: int) -> int:
+async def do_broadcast_course(update: Update, context: ContextTypes.DEFAULT_TYPE, course_id: int,
+                              reply_markup: InlineKeyboardMarkup = None) -> int:
     logging.info(f"{constants.id_to_course[course_id]}_broadcast handler triggered by {helpers.get_user(update)}")
     with Session(engine) as session:
         course_enrollments = session.query(Enrollment.tg_id).filter(Enrollment.course_id == course_id).all()
@@ -191,7 +198,9 @@ async def do_broadcast_course(update: Update, context: ContextTypes.DEFAULT_TYPE
             await context.bot.send_message(
                 chat_id=tg_id,
                 text=update.message.text,
-                entities=update.message.entities
+                entities=update.message.entities,
+                reply_markup=reply_markup,
+                parse_mode="HTML"
             )
             successful_count += 1
         except Exception as e:

--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -241,6 +241,34 @@ leetcode_broadcast_conv_handler = ConversationHandler(
     fallbacks=[CommandHandler('cancel_broadcast', cancel_broadcast)],
 )
 
+LEETCODE_NEW_TOPIC = 1
+
+
+@is_admin
+async def start_leetcode_new_topic_broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    logging.info(f"start_leetcode_new_topic_broadcast handler triggered by {helpers.get_user(update)}")
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f"Send the new topic for Leetcode"
+    )
+    return LEETCODE_NEW_TOPIC
+
+
+@is_admin
+async def leetcode_new_topic_broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    button_list = [
+        InlineKeyboardButton("Записаться на моки!", callback_data="leetcode_register"),
+    ]
+    menu = [button_list[i:i + 1] for i in range(0, len(button_list), 1)]
+
+    return await do_broadcast_course(update, context, constants.leetcode_course_id, InlineKeyboardMarkup(menu))
+
+
+leetcode_new_topic_broadcast = ConversationHandler(
+    entry_points=[CommandHandler('leetcode_new_topic', start_leetcode_new_topic_broadcast)],
+    states={LEETCODE_NEW_TOPIC: [MessageHandler(filters.TEXT & ~filters.COMMAND, leetcode_new_topic_broadcast)]},
+    fallbacks=[CommandHandler('cancel_broadcast', cancel_broadcast)],
+)
 
 SRE_BROADCAST = 1
 

--- a/handlers/handlers.py
+++ b/handlers/handlers.py
@@ -5,7 +5,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, User
-from telegram.ext import ContextTypes
+from telegram.ext import (CallbackQueryHandler, CommandHandler, ContextTypes, ConversationHandler, MessageHandler,
+                          filters)
 
 import constants
 import helpers
@@ -233,3 +234,192 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
             chat_id=settings.ADMIN_CHAT_ID,
             text=f"error triggered by {helpers.get_user(update)}: {context.error}",
             parse_mode="HTML")
+
+
+LEETCODE_FIRST_PROBLEM, LEETCODE_SECOND_PROBLEM, LEETCODE_TIMESLOTS, LEETCODE_PROGRAMMING_LANGUAGE, LEETCODE_ENGLISH =\
+    range(5)
+
+
+async def start_leetcode_register(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    if update.callback_query:
+        await update.callback_query.answer()
+    logging.info(f"start_leetcode_register handler triggered by {helpers.get_user(update)}")
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f"Пришли ссылку на задачу, которую ты будешь спрашивать как интервьюер"
+    )
+    return LEETCODE_FIRST_PROBLEM
+
+
+async def leetcode_first_problem(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    logging.info(f"leetcode_first_problem handler triggered by {helpers.get_user(update)}, first problem is "
+                 f"{update.message.text}")
+    context.user_data["first_problem"] = update.message.text
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f"Отлично! Теперь пришли ссылку на запасную задачу, на случай, если партнер уже решал основную задачу"
+    )
+    return LEETCODE_SECOND_PROBLEM
+
+
+def create_timeslots(_: Update, context: ContextTypes.DEFAULT_TYPE):
+    button_list = []
+    for i, option in enumerate(constants.leetcode_register_timeslots):
+        checked = "✅ " if i in context.user_data["selected_timeslots"] else ""
+        button_list.append([
+            InlineKeyboardButton(f"{checked}{option}", callback_data=f"leetcode_timeslot_{i}")
+        ])
+
+    if len(context.user_data["selected_timeslots"]) >= 3:
+        button_list.append([InlineKeyboardButton("➡️ Продолжить", callback_data="leetcode_timeslot_continue")])
+
+    return button_list
+
+
+async def leetcode_second_problem(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    logging.info(f"leetcode_second_problem handler triggered by {helpers.get_user(update)}, "
+                 f"user data = {context.user_data}, second problem is {update.message.text}")
+    context.user_data["second_problem"] = update.message.text
+
+    if "selected_timeslots" not in context.user_data:
+        context.user_data["selected_timeslots"] = set()
+
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=constants.leetcode_register_ask_timeslots,
+        reply_markup=InlineKeyboardMarkup(create_timeslots(update, context)),
+        parse_mode="HTML")
+    return LEETCODE_TIMESLOTS
+
+
+async def edit_timeslots(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    logging.info(f"edit_timeslots handler triggered by {helpers.get_user(update)}, user data = {context.user_data}, "
+                 f"update = {update.callback_query.data}")
+
+    await update.callback_query.edit_message_text(
+        text=constants.leetcode_register_ask_timeslots,
+        reply_markup=InlineKeyboardMarkup(create_timeslots(update, context)),
+        parse_mode="HTML")
+    return LEETCODE_TIMESLOTS
+
+
+async def leetcode_timeslot_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logging.info(f"leetcode_timeslot_handler handler triggered by {helpers.get_user(update)}, "
+                 f"user data = {context.user_data}, update = {update.callback_query.data}")
+    # save info about timeslots
+    query = update.callback_query
+    await query.answer()  # Acknowledge the callback
+
+    if not query.data.startswith("leetcode_timeslot_"):
+        raise ValueError(f"Unexpected callback, data={query.data}, user={helpers.get_user(update)}")
+
+    arg = query.data.split("_")[-1]
+    if arg.isnumeric():
+        idx = int(arg)
+        if idx in context.user_data["selected_timeslots"]:
+            context.user_data["selected_timeslots"].remove(idx)
+        else:
+            context.user_data["selected_timeslots"].add(idx)
+        await edit_timeslots(update, context)
+    else:
+        logging.info(f"user continued in timeslots, selected_timeslots timeslots = "
+                     f"{context.user_data['selected_timeslots']}, arg={arg}")
+        if arg != "continue":
+            raise ValueError(f"Unexpected callback, data={query.data}, user={helpers.get_user(update)}")
+        else:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text=f"На каком языке программирования будешь решать задачу?"
+            )
+            return LEETCODE_PROGRAMMING_LANGUAGE
+
+
+async def leetcode_programming_language(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    logging.info(f"leetcode_programming_language handler triggered by {helpers.get_user(update)}, "
+                 f"user data = {context.user_data}, programming language = {update.message.text}")
+    context.user_data["leetcode_programming_language"] = update.message.text
+
+    button_list = [
+        [InlineKeyboardButton(f"Да", callback_data=f"leetcode_english_yes")],
+        [InlineKeyboardButton(f"Нет", callback_data=f"leetcode_english_no")]
+    ]
+
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f"Готов проходить мок-собеседование на английском?",
+        reply_markup=InlineKeyboardMarkup(button_list),
+        parse_mode="HTML"
+    )
+    return LEETCODE_ENGLISH
+
+
+async def leetcode_english(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.callback_query.answer()  # Acknowledge the callback
+    logging.info(f"leetcode_english handler triggered by {helpers.get_user(update)}, user data = {context.user_data}, "
+                 f"english_choice = {update.callback_query.data}")
+    if update.callback_query.data == "leetcode_english_yes":
+        context.user_data["leetcode_english"] = True
+    elif update.callback_query.data == "leetcode_english_no":
+        context.user_data["leetcode_english"] = False
+    else:
+        raise ValueError(f"Unexpected callback_data = {update.callback_query.data} by {helpers.get_user(update)}")
+
+    english_string = 'Мок будет на английском, если партнер тоже может на англиском, иначе на русском' \
+        if context.user_data['leetcode_english'] else 'Мок будет на русском языке'
+    timeslots_string = ", ".join(
+        [constants.leetcode_register_timeslots[i] for i in context.user_data['selected_timeslots']])
+
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f"<b>Твой выбор</b>\n\n"
+             f"Основная задача: {context.user_data['first_problem']}\n"
+             f"Запасная задача: {context.user_data['second_problem']}\n"
+             f"Выбранные таймслоты: {timeslots_string + ' по Московскому времени'}\n"
+             f"Язык программирования: {context.user_data['leetcode_programming_language']}\n"
+             f"{english_string}\n\n"
+             f"В пятницу утром я объявлю твоего партнера на эту неделю\n\n"
+             f"Если хочешь изменить свой выбор, используй команду /leetcode_register. Если не хочешь участвовать в "
+             f"мок-собеседовании на этой неделе, используй команду /cancel_leetcode_register. Если есть вопросы, напиши"
+             f" @lenka_colenka",
+        parse_mode="HTML"
+    )
+    # todo: save to db
+    return ConversationHandler.END
+
+
+async def cancel_leetcode_register(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    logging.info(f"cancel_leetcode_register handler triggered by {helpers.get_user(update)}")
+    if "first_problem" in context.user_data:
+        del context.user_data["first_problem"]
+    if "second_problem" in context.user_data:
+        del context.user_data["second_problem"]
+    if "selected_timeslots" in context.user_data:
+        del context.user_data["selected_timeslots"]
+    if "leetcode_programming_language" in context.user_data:
+        del context.user_data["leetcode_programming_language"]
+    if "leetcode_english" in context.user_data:
+        del context.user_data["leetcode_english"]
+
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text="Ты не будешь участвовать в мок-собеседовании на этой неделе")
+    return ConversationHandler.END
+
+
+leetcode_register_handler = ConversationHandler(
+    entry_points=[
+        # todo: leetcode_register should work only after announcing topic on monday till Thursday evening, other time
+        # it should say "wait"
+        CommandHandler('leetcode_register', start_leetcode_register),
+        CallbackQueryHandler(start_leetcode_register, '^leetcode_register$')
+    ],
+    states={
+        LEETCODE_FIRST_PROBLEM: [MessageHandler(filters.TEXT & ~filters.COMMAND, leetcode_first_problem)],
+        LEETCODE_SECOND_PROBLEM: [MessageHandler(filters.TEXT & ~filters.COMMAND, leetcode_second_problem)],
+        LEETCODE_TIMESLOTS: [CallbackQueryHandler(leetcode_timeslot_handler, "^leetcode_timeslot")],
+        LEETCODE_PROGRAMMING_LANGUAGE: [MessageHandler(filters.TEXT & ~filters.COMMAND, leetcode_programming_language)],
+        LEETCODE_ENGLISH: [CallbackQueryHandler(leetcode_english, "^leetcode_english")]
+    },
+    fallbacks=[CommandHandler('leetcode_register', start_leetcode_register),
+               CommandHandler('cancel_leetcode_register', cancel_leetcode_register)],
+)

--- a/leetcode_pairs/.gitignore
+++ b/leetcode_pairs/.gitignore
@@ -1,0 +1,3 @@
+a.out
+edges_to_delete.txt
+graph_for_week_n

--- a/leetcode_pairs/generate_graph.py
+++ b/leetcode_pairs/generate_graph.py
@@ -1,0 +1,27 @@
+import os
+
+# todo: get them programmatically
+users = [0, 4, 5, 7, 10, 11, 13]
+
+graph = set()
+for i in range(len(users)):
+    for j in range(i+1, len(users)):
+        graph.add((users[i], users[j]))
+print(f"len(graph) = {len(graph)}")
+
+with open('edges_to_delete.txt', 'r') as f:
+    for line in f.readlines():
+        (a, b) = [int(item) for item in line.split()]
+        print(f"a = {a}, b = {b}")
+        if (a, b) in graph:
+            graph.remove((a, b))
+
+print(f"after deletion len(graph) = {len(graph)}")
+
+with open('graph_for_week_n', 'w') as f:
+    f.write(f"14 {len(graph)}\n")
+    for (a, b) in graph:
+        f.write(f"{a} {b}\n")
+
+ans = os.popen("./a.out < graph_for_week_n").read()
+print(f"==========\n{ans}")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import logging
-from telegram.ext import (filters, ApplicationBuilder, CommandHandler, ConversationHandler, MessageHandler,
-                          CallbackQueryHandler)
+from telegram.ext import (filters, ApplicationBuilder, CommandHandler, MessageHandler, CallbackQueryHandler)
 
 from handlers import admin_commands, handlers, menu
 import notifications
@@ -16,43 +15,10 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 if __name__ == '__main__':
     application = ApplicationBuilder().token(settings.TELEGRAM_TOKEN).build()
 
-    echo_conv_handler = ConversationHandler(
-        entry_points=[CommandHandler('echo', admin_commands.start_echo)],
-        states={
-            admin_commands.ECHO: [MessageHandler(filters.TEXT & ~filters.COMMAND, admin_commands.echo_message)]
-        },
-        fallbacks=[CommandHandler('cancel_echo', admin_commands.cancel_echo)],
-    )
-
-    # todo: make sure it doesn't mess up with multiple admins
-    broadcast_conv_handler = ConversationHandler(
-        entry_points=[CommandHandler('broadcast', admin_commands.start_broadcast)],
-        states={
-            admin_commands.BROADCAST: [MessageHandler(filters.TEXT & ~filters.COMMAND, admin_commands.broadcast)]
-        },
-        fallbacks=[CommandHandler('cancel_broadcast', admin_commands.cancel_broadcast)],
-    )
-
-    leetcode_broadcast_conv_handler = ConversationHandler(
-        entry_points=[CommandHandler('leetcode_broadcast', admin_commands.start_leetcode_broadcast)],
-        states={
-            admin_commands.BROADCAST: [MessageHandler(filters.TEXT & ~filters.COMMAND, admin_commands.leetcode_broadcast)]
-        },
-        fallbacks=[CommandHandler('cancel_broadcast', admin_commands.cancel_broadcast)],
-    )
-
-    sre_broadcast_conv_handler = ConversationHandler(
-        entry_points=[CommandHandler('sre_broadcast', admin_commands.start_sre_broadcast)],
-        states={
-            admin_commands.BROADCAST: [MessageHandler(filters.TEXT & ~filters.COMMAND, admin_commands.sre_broadcast)]
-        },
-        fallbacks=[CommandHandler('cancel_broadcast', admin_commands.cancel_broadcast)],
-    )
-
-    application.add_handler(echo_conv_handler)
-    application.add_handler(broadcast_conv_handler)
-    application.add_handler(leetcode_broadcast_conv_handler)
-    application.add_handler(sre_broadcast_conv_handler)
+    application.add_handler(admin_commands.echo_conv_handler)
+    application.add_handler(admin_commands.broadcast_conv_handler)
+    application.add_handler(admin_commands.leetcode_broadcast_conv_handler)
+    application.add_handler(admin_commands.sre_broadcast_conv_handler)
 
     application.add_handler(CommandHandler('start', menu.start))
     application.add_handler(CommandHandler('help', menu.command_help))

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
     application.add_handler(admin_commands.broadcast_conv_handler)
     application.add_handler(admin_commands.leetcode_broadcast_conv_handler)
     application.add_handler(admin_commands.sre_broadcast_conv_handler)
+    application.add_handler(admin_commands.leetcode_new_topic_broadcast)
 
     application.add_handler(CommandHandler('start', menu.start))
     application.add_handler(CommandHandler('help', menu.command_help))

--- a/main.py
+++ b/main.py
@@ -15,11 +15,15 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 if __name__ == '__main__':
     application = ApplicationBuilder().token(settings.TELEGRAM_TOKEN).build()
 
+    # conversation handlers
     application.add_handler(admin_commands.echo_conv_handler)
     application.add_handler(admin_commands.broadcast_conv_handler)
     application.add_handler(admin_commands.leetcode_broadcast_conv_handler)
     application.add_handler(admin_commands.sre_broadcast_conv_handler)
     application.add_handler(admin_commands.leetcode_new_topic_broadcast)
+    application.add_handler(handlers.leetcode_register_handler)
+
+    application.add_handler(CommandHandler('cancel_leetcode_register', handlers.cancel_leetcode_register))
 
     application.add_handler(CommandHandler('start', menu.start))
     application.add_handler(CommandHandler('help', menu.command_help))


### PR DESCRIPTION
## User visible changes

- /leetcode_register tiggers a workflow to add information about problems to ask, selected timeslots, programming language and English/Russian language
- /cancel_leetcode_register deletes info about leetcode signup this week

### Admin API
- `/leetcode_new_topic` send a message to Leetcode users with a new topic and a button to sign up for Leetcode mocks this week
- `cancel_broadcast` cancels sending a new topic to Leetcode users

## Deployment changes

- none

**WIP!**
Data about user leetcode sign-up is not persisted to DB and logs will be used to get this info