### PR TITLE
clear user state when writing mock signup to db

### DIFF
--- a/handlers/leetcode_mock_handlers.py
+++ b/handlers/leetcode_mock_handlers.py
@@ -218,6 +218,7 @@ async def leetcode_english(update: Update, context: ContextTypes.DEFAULT_TYPE) -
              f" @lenka_colenka",
         parse_mode="HTML"
     )
+    clear_state(context)
     return ConversationHandler.END
 
 
@@ -250,6 +251,15 @@ async def cancel_leetcode_register(update: Update, context: ContextTypes.DEFAULT
             )
             return ConversationHandler.END
 
+    clear_state(context)
+
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text="Хорошо! Ты не будешь участвовать в мок-собеседовании на этой неделе")
+    return ConversationHandler.END
+
+
+def clear_state(context: ContextTypes.DEFAULT_TYPE) -> None:
     if "first_problem" in context.user_data:
         del context.user_data["first_problem"]
     if "second_problem" in context.user_data:
@@ -260,11 +270,6 @@ async def cancel_leetcode_register(update: Update, context: ContextTypes.DEFAULT
         del context.user_data["leetcode_programming_language"]
     if "leetcode_english" in context.user_data:
         del context.user_data["leetcode_english"]
-
-    await context.bot.send_message(
-        chat_id=update.effective_chat.id,
-        text="Хорошо! Ты не будешь участвовать в мок-собеседовании на этой неделе")
-    return ConversationHandler.END
 
 
 leetcode_register_handler = ConversationHandler(


### PR DESCRIPTION
# User-visible changes
 - when signing up for leetcode mocks, previous selection of timeslots doesn't show up
 
 # Deployment changes
  - clearer logs about leetcode signups when re-registering