### PR TITLE
use named volume for postgres docker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,3 +10,8 @@ services:
       - POSTGRES_DB=nelenkin_club
     ports:
       - 5432:5432
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,14 @@ services:
       - POSTGRES_DB=nelenkin_club
     ports:
       - 5432:5432
+    volumes:
+      - pgdata:/var/lib/postgresql/data
 
   adminer:
-      image: adminer
-      restart: always
-      ports:
-        - 8080:8080
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+
+volumes:
+  pgdata:


### PR DESCRIPTION
# User-visible changes
 - None

# Deployment changes
 - persist postgres data when the container is re-created. Before I relied on anonymous volume, but explicit volume should be more reliable