### PR TITLE
add handler to see Leetcode Grind users number

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -87,6 +87,7 @@ error_description = \
 leetcode_course_id: int = 7
 sre_course_id: int = 8
 ddia_4_course_id: int = 10
+grind_course_id: int = 11
 
 id_to_course = {7: "Leetcode", 8: "SRE", 10: "DDIA-4", 11: "Leetcode-Grind-2"}
 

--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -117,6 +117,20 @@ async def get_sre_users_handler(update: Update, context: ContextTypes.DEFAULT_TY
     )
 
 
+@is_curator(constants.grind_course_id)
+async def get_grind_users_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logging.info(f"get_grind_users handler triggered by {helpers.repr_user_from_update(update)}")
+
+    with Session(models.engine) as session:
+        grind_users_count = session.query(models.Enrollment.tg_id).filter(
+            models.Enrollment.course_id == constants.grind_course_id).count()
+
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f"{grind_users_count} users are enrolled in Leetcode Grind"
+    )
+
+
 @is_curator(constants.ddia_4_course_id)
 async def get_ddia_users_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     logging.info(f"get_ddia_users_handler handler triggered by {helpers.repr_user_from_update(update)}")

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
     application.add_handler(CommandHandler('get_users', admin_commands.get_users_handler))
     application.add_handler(CommandHandler('get_sre_users', admin_commands.get_sre_users_handler))
     application.add_handler(CommandHandler('get_ddia_users', admin_commands.get_ddia_users_handler))
+    application.add_handler(CommandHandler('get_grind_users', admin_commands.get_grind_users_handler))
     application.add_handler(CommandHandler('leetcode_on', admin_commands.leetcode_on))
     application.add_handler(CommandHandler('leetcode_off', admin_commands.leetcode_off))
     application.add_handler(CommandHandler('sre_notification_on', admin_commands.sre_notification_on))


### PR DESCRIPTION
# User visible changes
## Admin API
 - /get_grind_users  admin and leetcode grind curator can see how many people are enrolled to Leetcode Grind

# Deployment changes
 - None