### PR TITLE
`/get_dmls_users` and `/dmls_broadcast`

### DIFF
--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -437,6 +437,33 @@ ddia_broadcast_conv_handler = ConversationHandler(
     ],
 )
 
+DMLS_BROADCAST = 1
+
+
+@is_curator(constants.dmls_course_id)
+async def start_dmls_broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    logging.info(f"start_dmls_broadcast handler triggered by {helpers.repr_user_from_update(update)}")
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f"Send a message to broadcast to DMLS users"
+    )
+    return DMLS_BROADCAST
+
+
+@is_curator(constants.dmls_course_id)
+async def dmls_broadcast(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    return await do_broadcast_course(update, context, constants.dmls_course_id)
+
+
+dmls_broadcast_conv_handler = ConversationHandler(
+    entry_points=[CommandHandler('dmls_broadcast', start_dmls_broadcast, filters.ChatType.PRIVATE)],
+    states={DMLS_BROADCAST: [MessageHandler(~filters.COMMAND, dmls_broadcast)]},
+    fallbacks=[
+        CommandHandler('cancel_broadcast', cancel_broadcast),
+        CommandHandler('cancel', cancel_broadcast),
+    ],
+)
+
 
 GRIND_BROADCAST = 1
 

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ if __name__ == '__main__':
     application.add_handler(admin_commands.leetcode_broadcast_conv_handler)
     application.add_handler(admin_commands.sre_broadcast_conv_handler)
     application.add_handler(admin_commands.ddia_broadcast_conv_handler)
+    application.add_handler(admin_commands.dmls_broadcast_conv_handler)
     application.add_handler(admin_commands.grind_broadcast_conv_handler)
     application.add_handler(admin_commands.leetcode_new_topic_broadcast)
     application.add_handler(leetcode_mock_handlers.leetcode_register_handler)


### PR DESCRIPTION
# User-visible changes
 - DMLS curator now can use `/get_dmls_users` to know how many people enrolled and `/dmls_broadcast` to broadcast a message to everyone enrolled to DMLS