### PR TITLE
fix: add migration for unique tg_id in Users

### DIFF
--- a/alembic/versions/d8f9740920a6_add_curators_to_course.py
+++ b/alembic/versions/d8f9740920a6_add_curators_to_course.py
@@ -20,9 +20,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    op.create_unique_constraint(op.f('Users_unique_tg_id'), 'Users', ['tg_id'])
     op.add_column('Course', sa.Column('curator_tg_id', sa.Text(), nullable=True))
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     op.drop_column('Course', 'curator_tg_id')
+    op.drop_constraint(op.f('Users_unique_tg_id'), 'Users', type_='unique')


### PR DESCRIPTION
# Deployment changes
 - Fix the migration that was added earlier. Unique constraint for tg_id in table Users was added to models.py in https://github.com/LenaAn/neLenkin_bot/pull/33/changes/7b4ff7465671090946bcf1c1227a6306fe1a0b0e, but wasn't added to migration. Because of that later migration fcfbd017c142 is not able to be applied.
 - The bug was found by @alurm when trying to set up bot to run locally. Looks like on my setup I managed to to add this unique constraint manually both to my manual setup and prod.