### PR TITLE
CourseNotification table: separate logic for sending Patreon reminders and active courses

### DIFF
--- a/alembic/versions/070a62f5bd23_separate_table_for_course_notifications.py
+++ b/alembic/versions/070a62f5bd23_separate_table_for_course_notifications.py
@@ -1,0 +1,40 @@
+"""separate table for course notifications
+
+Revision ID: 070a62f5bd23
+Revises: 6e46b4ba237c
+Create Date: 2026-05-19 13:34:19.799276
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '070a62f5bd23'
+down_revision: Union[str, Sequence[str], None] = '6e46b4ba237c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('CourseNotification',
+    sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+    sa.Column('course_id', sa.Integer(), nullable=False),
+    sa.Column('is_zoom_link_only_to_pro', sa.Boolean(), nullable=False),
+    sa.Column('send_patreon_reminder', sa.Boolean(), nullable=False),
+    sa.Column('day_of_week', sa.Integer(), nullable=False),
+    sa.Column('hour', sa.Integer(), nullable=False),
+    sa.CheckConstraint('day_of_week BETWEEN 0 AND 6', name='check_day_of_week_range'),
+    sa.CheckConstraint('hour BETWEEN 0 AND 23', name='check_hour_of_day_range'),
+    sa.ForeignKeyConstraint(['course_id'], ['Course.id'], name='fk_valid_course_id'),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('course_id', name='Single_notification_per_course')
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('CourseNotification')

--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -679,27 +679,6 @@ async def aoc_notification_off(update: Update, context: ContextTypes.DEFAULT_TYP
     )
 
 
-@is_admin
-async def pro_courses_on(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    logging.info(f"pro_courses_on handler triggered by {helpers.repr_user_from_update(update)}")
-    models.pro_courses_on = True
-
-    await context.bot.send_message(
-        chat_id=update.effective_chat.id,
-        text="PRO coursee are ON" if models.pro_courses_on else "PRO courses are OFF"
-    )
-
-
-@is_admin
-async def pro_courses_off(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    logging.info(f"pro_courses_off handler triggered by {helpers.repr_user_from_update(update)}")
-    models.pro_courses_on = False
-
-    await context.bot.send_message(
-        chat_id=update.effective_chat.id,
-        text="PRO coursee are ON" if models.pro_courses_on else "PRO courses are OFF"
-    )
-
 # This method is of limited functionality because not every telegram user has a username.
 # Currently, in order to present, one has to sign up to a spreadsheet with their tg_id, so I guess this should be good
 # enough. If it's impossible to track down user by tg username, admin manual operation is required.

--- a/main.py
+++ b/main.py
@@ -83,10 +83,6 @@ if __name__ == '__main__':
         CommandHandler('aoc_notification_off', admin_commands.aoc_notification_off,
                        filters.ChatType.PRIVATE))
     application.add_handler(
-        CommandHandler('pro_courses_on', admin_commands.pro_courses_on, filters.ChatType.PRIVATE))
-    application.add_handler(
-        CommandHandler('pro_courses_off', admin_commands.pro_courses_off, filters.ChatType.PRIVATE))
-    application.add_handler(
         MessageHandler(filters.ChatType.PRIVATE & ~filters.COMMAND, menu.private_message))
 
     application.add_handler(CallbackQueryHandler(button_handlers.button_click))

--- a/models.py
+++ b/models.py
@@ -68,7 +68,9 @@ class Course(Base):
     curator_tg_id = Column(sqlalchemy.Text, nullable=True)
     is_active = Column(sqlalchemy.Boolean, nullable=False)
     is_pro = Column(sqlalchemy.Boolean, nullable=True)
+    # deprecated
     day_of_week = Column(sqlalchemy.Integer, nullable=True)  # 0 = Sunday
+    # deprecated
     hour = Column(sqlalchemy.Integer, nullable=True)
 
     __table_args__ = (
@@ -80,6 +82,24 @@ class Course(Base):
 
     def __repr__(self):
         return f"Course(id={self.id}, name={self.name}"
+
+
+class CourseNotification(Base):
+    __tablename__ = 'CourseNotification'
+
+    id = Column(sqlalchemy.Integer, primary_key=True, autoincrement=True)
+    course_id = Column(sqlalchemy.Integer, nullable=False)
+    is_zoom_link_only_to_pro = Column(sqlalchemy.Boolean, nullable=False)
+    send_patreon_reminder = Column(sqlalchemy.Boolean, nullable=False)
+    day_of_week = Column(sqlalchemy.Integer, nullable=False)  # 0 = Sunday, 1 = Monday
+    hour = Column(sqlalchemy.Integer, nullable=False)
+
+    __table_args__ = (
+        sqlalchemy.UniqueConstraint('course_id', name='Single_notification_per_course'),
+        sqlalchemy.ForeignKeyConstraint(['course_id'], ['Course.id'], name='fk_valid_course_id'),
+        sqlalchemy.CheckConstraint("hour BETWEEN 0 AND 23", name="check_hour_of_day_range"),
+        sqlalchemy.CheckConstraint("day_of_week BETWEEN 0 AND 6", name="check_day_of_week_range"),
+    )
 
 
 # supposed to be short-lived (couple of months data)

--- a/models.py
+++ b/models.py
@@ -81,7 +81,7 @@ class Course(Base):
     )
 
     def __repr__(self):
-        return f"Course(id={self.id}, name={self.name}"
+        return f"Course(id={self.id}, name={self.name})"
 
 
 class CourseNotification(Base):
@@ -100,6 +100,9 @@ class CourseNotification(Base):
         sqlalchemy.CheckConstraint("hour BETWEEN 0 AND 23", name="check_hour_of_day_range"),
         sqlalchemy.CheckConstraint("day_of_week BETWEEN 0 AND 6", name="check_day_of_week_range"),
     )
+
+    def __repr__(self):
+        return f"CourseNotification(course_id={self.course_id}, day={self.day_of_week}, hour={self.hour})"
 
 
 # supposed to be short-lived (couple of months data)

--- a/models.py
+++ b/models.py
@@ -218,5 +218,4 @@ engine = create_engine(DATABASE_URL)
 # todo: these are essentially feature flags, but are not persisted across restarts. Need a nicer way to work with
 #  feature flags.
 leetcode_status_on = True
-pro_courses_on=True
 aoc_notification_on = False

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -171,7 +171,7 @@ async def prompt_to_connect_patreon_notifications(context: ContextTypes.DEFAULT_
             parse_mode="HTML")
         return
 
-    notifications_logger.debug(f"prompt_to_connect_patreon_notifications for {constants.id_to_course[course_id]}")
+    notifications_logger.info(f"prompt_to_connect_patreon_notifications for {constants.id_to_course[course_id]}")
 
     if course_id == constants.ddia_5_course_id:
             message: str = ("Привет! Сегодня вечером будет звонок с обсуждением Designing Data-Intensive Applications. Тему "
@@ -220,14 +220,14 @@ async def prompt_to_connect_patreon_notifications(context: ContextTypes.DEFAULT_
     with Session(engine) as session:
         result = session.query(Enrollment.tg_id).filter(Enrollment.course_id == course_id).all()
         notification_chat_ids = [item[0] for item in result]
-    notifications_logger.debug(f"handling Patreon prompt for {constants.id_to_course[course_id]}, got "
-                               f"{len(notification_chat_ids)} chat ids that are subscribed to the course")
+    notifications_logger.info(f"handling Patreon prompt for {constants.id_to_course[course_id]}, got "
+                              f"{len(notification_chat_ids)} chat ids that are subscribed to the course")
 
     # only Basic subscribers will get a prompt to subscribe to Patreon
     notification_chat_ids = [tg_id for tg_id in notification_chat_ids
                              if membership.get_user_membership_info(tg_id).get_overall_level() == membership.basic]
-    notifications_logger.debug(f"handling Patreon prompt for {constants.id_to_course[course_id]}, got "
-                               f"{len(notification_chat_ids)} Basic subscribers to {constants.id_to_course[course_id]}")
+    notifications_logger.info(f"handling Patreon prompt for {constants.id_to_course[course_id]}, got "
+                              f"{len(notification_chat_ids)} Basic subscribers to {constants.id_to_course[course_id]}")
 
     await notifications_helpers.do_send_notifications(context, notification_chat_ids, message, menu,
                                                       f"{constants.id_to_course[course_id]} Patreon prompt")
@@ -269,13 +269,14 @@ def get_active_courses_today(hour: int = None) -> list:
     today_weekday: int = (datetime.datetime.now().weekday() + 1) % 7
 
     with Session(models.engine) as session:
-        query = session.query(models.Course).filter(
-            (models.Course.is_active.is_(True) & (models.Course.day_of_week == today_weekday))
+        query = session.query(models.Course, models.CourseNotification
+                              ).join(models.CourseNotification, models.Course.id == models.CourseNotification.course_id
+                                     ).filter(
+            (models.Course.is_active.is_(True) & (models.CourseNotification.day_of_week == today_weekday))
         )
 
         if hour is not None:
-            query = query.filter(models.Course.hour == hour)
-
+            query = query.filter(models.CourseNotification.hour == hour)
         active_courses_with_notification_today = query.all()
 
     notifications_logger.info(f"active courses for weekday {today_weekday} with hour {hour} are: "
@@ -296,10 +297,12 @@ async def get_active_courses_and_prompt_to_get_pro(context: ContextTypes.DEFAULT
     notifications_logger.info(f"triggered get_active_courses_and_prompt_to_get_pro")
 
     active_courses_today: list[models.Course] = get_active_courses_today()
-    for course in active_courses_today:
-        if course.is_pro:
+    for course, notification in active_courses_today:
+        if notification.send_patreon_reminder:
             context.job.data = {"course_id": course.id}
             await prompt_to_connect_patreon_notifications(context)
+        else:
+            notifications_logger.info(f"skipping patreon prompt for {course} since send_patreon_reminder is False")
 
 
 # every day the job checks for active courses with today's day of the week

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -86,20 +86,10 @@ async def handle_notification(context: ContextTypes.DEFAULT_TYPE):
                                f"got {len(notification_chat_ids)} chat ids that are subscribed to the course")
 
     if course_handlers.is_course_pro(course_id):
-        if models.pro_courses_on:
-            # only PRO subscribers will get a link for a PRO course
-            # Basic subscribers who are subscribed to notifications about this course will get a Patreon link in the morning
-            notification_chat_ids = [tg_id for tg_id in notification_chat_ids
-                                     if
-                                     membership.get_user_membership_info(tg_id).get_overall_level() == membership.pro]
-            notifications_logger.debug(f"handling {constants.id_to_course[course_id]} notification, "
-                                       f"got {len(notification_chat_ids)} PRO subscribers")
-        else:
-            notifications_logger.debug(f"Sending a link to everyone because PRO courses are turned off")
-            await context.bot.send_message(
-                chat_id=settings.ADMIN_CHAT_ID,
-                text=f"Sending a link to everyone because PRO courses are turned off",
-                parse_mode="HTML")
+        notification_chat_ids = [tg_id for tg_id in notification_chat_ids
+                                 if membership.get_user_membership_info(tg_id).get_overall_level() == membership.pro]
+        notifications_logger.debug(f"handling {constants.id_to_course[course_id]} notification, "
+                                   f"got {len(notification_chat_ids)} PRO subscribers")
     else:
         notifications_logger.debug(f"Sending a link to everyone because course {course_id} is NOT Pro")
 
@@ -160,17 +150,6 @@ async def handle_notification_for_course(context: ContextTypes.DEFAULT_TYPE):
 async def prompt_to_connect_patreon_notifications(context: ContextTypes.DEFAULT_TYPE):
     # todo: don't hardcode things, move table links and buttons to constants
     course_id: int = context.job.data["course_id"]
-
-    if not models.pro_courses_on:
-        notifications_logger.info(f"Skipping a prompt to connect Patreon for course {constants.id_to_course[course_id]}"
-                                  f" because PRO courses are turned off")
-        await context.bot.send_message(
-            chat_id=settings.ADMIN_CHAT_ID,
-            text=f"Skipping {constants.id_to_course[course_id]} prompt to connect Patreon because PRO courses are "
-                 f"turned off",
-            parse_mode="HTML")
-        return
-
     notifications_logger.info(f"prompt_to_connect_patreon_notifications for {constants.id_to_course[course_id]}")
 
     if course_id == constants.ddia_5_course_id:

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -148,47 +148,20 @@ async def handle_notification_for_course(context: ContextTypes.DEFAULT_TYPE):
 
 
 async def prompt_to_connect_patreon_notifications(context: ContextTypes.DEFAULT_TYPE):
-    # todo: don't hardcode things, move table links and buttons to constants
     course_id: int = context.job.data["course_id"]
     notifications_logger.info(f"prompt_to_connect_patreon_notifications for {constants.id_to_course[course_id]}")
 
-    if course_id == constants.ddia_5_course_id:
-            message: str = ("Привет! Сегодня вечером будет звонок с обсуждением Designing Data-Intensive Applications. Тему "
-                    "сегодняшнего звонка можешь посмотреть <a href='https://docs.google.com/spreadsheets/d/1Q1brVbkrS-PDNRrmigOVN_AF8yGGHslLsBzVumkv9-0/edit?usp=sharing'>здесь</a>. "
-                    "\n\n<b>Обсуждение DDIA — это 💜Pro курс, и чтобы сегодня вечером тебе пришла ссылка на звонок, нужна 💜Pro подписка!</b>"
-                    "\n\n1. Чтобы оформить Pro подписку, подпишись на донат в $15 в месяц на моем "
-                    "<a href='https://www.patreon.com/c/LenaAnyusha'>Patreon</a>."
-                    "\n\nНикому не говори почту, которая привязана к твоему Patreon аккаунту! Когда оформишь подписку на Patreon, "
-                    "привяжи почту по кнопке ⬇️"
-                    "\n\n2. Либо оформи подписку на 1500 рублей на мой <a href='https://boosty.to/lenaan'>Boosty</a> и привяжи почту по кнопке ⬇️"                    "\n\n3. Если возникнут какие-то сложности, напиши @lenka_colenka!"
-                    "\n\n4. Ты можешь отписаться от новостей про DDIA, чтобы больше не получать уведомления.")
-    elif course_id == constants.leetcode_grind_3_course_id:
-        message: str = (
-            "Привет! Сегодня вечером будет звонок с обсуждением задач из списка Leetcode-75! Тему "
-            "сегодняшнего звонка можешь посмотреть <a href='https://docs.google.com/spreadsheets/d/1ddCs4c4km3qFeyzyvzuQn6a9lC_V5M2ocyT8w9ShBwg/edit?gid=0'>здесь</a>. "
-            "\n\n<b>Обсуждение Leetcode Grind — это 💜Pro курс, и чтобы сегодня вечером тебе пришла ссылка на звонок, нужна 💜Pro подписка!</b>"
-            "\n\n1. Чтобы оформить Pro подписку, подпишись на донат в $15 в месяц на моем "
-            "<a href='https://www.patreon.com/c/LenaAnyusha'>Patreon</a>."
-            "\n\nНикому не говори почту, которая привязана к твоему Patreon аккаунту! Когда оформишь подписку на Patreon, "
-            "привяжи почту по кнопке ⬇️"
-            "\n\n2. Либо оформи подписку на 1500 рублей на мой <a href='https://boosty.to/lenaan'>Boosty</a> и привяжи почту по кнопке ⬇️"
-            "\n\n3. Если возникнут какие-то сложности, напиши @lenka_colenka!"
-            "\n\n4. Ты можешь отписаться от новостей про Leetcode Grind, чтобы больше не получать уведомления.")
-    elif course_id == constants.dmls_course_id:
-        message: str = (
-            "Привет! Сегодня вечером будет звонок с обсуждением <a href='https://www.oreilly.com/library/view/designing-machine-learning/9781098107956/'>Designing Machine Learning Systems</a>. "
-            "Тему сегодняшнего звонка можешь посмотреть <a href='https://docs.google.com/spreadsheets/d/12ZfAfGceVuPZZoWbmHaSPcwe1mLTl9Jg9YONP7JkmsQ/edit?gid=0#gid=0'>в таблице</a>. "
-            "\n\n<b>Обсуждение DMLS — это 💜Pro курс, и чтобы сегодня вечером тебе пришла ссылка на звонок, нужна 💜Pro подписка!</b>"
-            "\n\n1. Чтобы оформить Pro подписку, подпишись на донат в $15 в месяц на моем "
-            "<a href='https://www.patreon.com/c/LenaAnyusha'>Patreon</a>. "
-            "\n\nНикому не говори почту, которая привязана к твоему Patreon аккаунту! Когда оформишь подписку на Patreon, "
-            "привяжи почту по кнопке ⬇️"
-            "\n\n2. Либо оформи подписку на 1500 рублей на мой <a href='https://boosty.to/lenaan'>Boosty</a> и привяжи почту по кнопке ⬇️"
-            "\n\n3. Если возникнут какие-то сложности, напиши @lenka_colenka!"
-            "\n\n4. Ты можешь отписаться от новостей про DMLS, чтобы больше не получать уведомления.")
-    else:
-        raise Exception("unsupported course id!")
-
+    message: str = (f"Привет! Сегодня вечером будет звонок с обсуждением {constants.id_to_course[course_id]}."
+                    f"\n\n<b>{constants.id_to_course[course_id]} — это 💜Pro курс, и чтобы сегодня вечером тебе пришла"
+                    f" ссылка на звонок, нужна 💜Pro подписка!</b>"
+                    f"\n\n1. Чтобы оформить Pro подписку, подпишись на донат в $15 в месяц на моем "
+                    f"<a href='https://www.patreon.com/c/LenaAnyusha'>Patreon</a>."
+                    f"\nКогда оформишь подписку на Patreon, привяжи почту по кнопке ⬇️"
+                    f"\n\n2. Либо оформи подписку на 1500 рублей на мой <a href='https://boosty.to/lenaan'>Boosty</a> и "
+                    f"привяжи почту по кнопке ⬇️"
+                    f"\n\n3. Если возникнут какие-то сложности, напиши @lenka_colenka!"
+                    f"\n\n4. Ты можешь отписаться от новостей про {constants.id_to_course[course_id]}, чтобы больше не "
+                    f"получать уведомления.")
     menu = InlineKeyboardMarkup([
         [InlineKeyboardButton("Привязать профиль Patreon", callback_data="connect_patreon")],
         [InlineKeyboardButton("Привязать профиль Boosty", callback_data="connect_boosty")],


### PR DESCRIPTION
# User-visible changes
 - Minor wording change of patreon reminder

# Deployment changes
 - New table `CourseNotification`
 - `day_of_week` and `hour` in Course are deprecated 
 - no more `pro_courses_on` flag
 - use info from `CourseNotification` to decide when to send a patreon prompt