### PR TITLE
Get rid of hour and day_of_week in Course

### DIFF
--- a/alembic/versions/0b01970a6e54_get_rid_of_hour_and_day_of_week_in_.py
+++ b/alembic/versions/0b01970a6e54_get_rid_of_hour_and_day_of_week_in_.py
@@ -1,0 +1,52 @@
+"""get rid of hour and day_of_week in course
+
+Revision ID: 0b01970a6e54
+Revises: 070a62f5bd23
+Create Date: 2026-05-19 15:47:44.821661
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0b01970a6e54'
+down_revision: Union[str, Sequence[str], None] = '070a62f5bd23'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_constraint(
+        constraint_name="check_day_of_week_range",
+        table_name="Course",
+        type_="check"
+    )
+    op.drop_constraint(
+        constraint_name="check_hour_of_day_range",
+        table_name="Course",
+        type_="check"
+    )
+    op.drop_column('Course', 'hour')
+    op.drop_column('Course', 'day_of_week')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    op.add_column('Course', sa.Column('day_of_week', sa.INTEGER(), autoincrement=False, nullable=True))
+    op.add_column('Course', sa.Column('hour', sa.INTEGER(), autoincrement=False, nullable=True))
+
+    op.create_check_constraint(
+        constraint_name="check_hour_of_day_range",
+        table_name="Course",
+        condition="hour BETWEEN 0 AND 23"
+    )
+    op.create_check_constraint(
+        constraint_name="check_day_of_week_range",
+        table_name="Course",
+        condition="day_of_week BETWEEN 0 AND 6"
+    )

--- a/models.py
+++ b/models.py
@@ -68,17 +68,6 @@ class Course(Base):
     curator_tg_id = Column(sqlalchemy.Text, nullable=True)
     is_active = Column(sqlalchemy.Boolean, nullable=False)
     is_pro = Column(sqlalchemy.Boolean, nullable=True)
-    # deprecated
-    day_of_week = Column(sqlalchemy.Integer, nullable=True)  # 0 = Sunday
-    # deprecated
-    hour = Column(sqlalchemy.Integer, nullable=True)
-
-    __table_args__ = (
-        sqlalchemy.CheckConstraint("day_of_week BETWEEN 0 AND 6", name="check_day_of_week_range"),
-    )
-    __table_args__ = (
-        sqlalchemy.CheckConstraint("hour BETWEEN 0 AND 23", name="check_hour_of_day_range"),
-    )
 
     def __repr__(self):
         return f"Course(id={self.id}, name={self.name})"

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -24,7 +24,7 @@ notifications_logger.setLevel(logging.DEBUG)
 
 async def register_notifications(application):
     await register_leetcode_notifications(application)
-    await register_daily_notification_for_active_courses(application)
+    await register_daily_send_zoom_for_active_courses(application)
     await register_daily_patreon_prompt_for_active_courses(application)
     await register_aoc_notifications(application)
 
@@ -65,7 +65,7 @@ async def handle_leetcode_reminder(context: ContextTypes.DEFAULT_TYPE):
                                                       constants.id_to_course[course_id])
 
 
-async def handle_notification(context: ContextTypes.DEFAULT_TYPE):
+async def handle_send_zoom(context: ContextTypes.DEFAULT_TYPE):
     course_id: int = context.job.data["course_id"]
     if "message" not in context.job.data:
         admin_chat_id = int(os.getenv('ADMIN_CHAT_ID'))
@@ -115,7 +115,7 @@ async def handle_aoc_notification(context: ContextTypes.DEFAULT_TYPE):
         notifications_logger.info("AoC notification is turned off, skipping sending notifications")
 
 
-async def handle_notification_for_course(context: ContextTypes.DEFAULT_TYPE):
+async def get_zoom_link_and_send_for_course(context: ContextTypes.DEFAULT_TYPE):
     course_id: int = context.job.data["course_id"]
     current_week: int = datetime.date.today().isocalendar().week
     with (Session(engine) as session):
@@ -144,7 +144,7 @@ async def handle_notification_for_course(context: ContextTypes.DEFAULT_TYPE):
         context.job.data["message"] = f"{constants.before_call_reminders[course_id]}\n\n{call_link}"
     else:
         context.job.data["message"] = constants.before_call_reminders[course_id]
-    await handle_notification(context)
+    await handle_send_zoom(context)
 
 
 async def prompt_to_connect_patreon_notifications(context: ContextTypes.DEFAULT_TYPE):
@@ -215,7 +215,7 @@ async def register_aoc_notifications(app):
     )
 
 
-def get_active_courses_today(hour: int = None) -> list:
+def get_active_courses_today(hour: int = None) -> list[tuple[models.Course, models.CourseNotification]]:
     # in app.job_queue.run_daily 0 = Sunday, so in db 0 = Sunday, 1 = Monday
     # but for datetime 0 = Monday
     today_weekday: int = (datetime.datetime.now().weekday() + 1) % 7
@@ -236,19 +236,20 @@ def get_active_courses_today(hour: int = None) -> list:
     return active_courses_with_notification_today
 
 
-async def get_active_courses_and_handle_notification(context: ContextTypes.DEFAULT_TYPE):
-    notifications_logger.info(f"triggered get_active_courses_and_handle_notification")
+async def get_active_courses_and_send_zoom(context: ContextTypes.DEFAULT_TYPE):
+    notifications_logger.info(f"triggered get_active_courses_and_send_zoom")
 
-    active_courses_today: list = get_active_courses_today(context.job.data["hour"])
-    for course in active_courses_today:
+    active_courses_today: list[tuple[models.Course, models.CourseNotification]] = (
+        get_active_courses_today(context.job.data["hour"]))
+    for course, notification in active_courses_today:
         context.job.data = {"course_id": course.id}
-        await handle_notification_for_course(context)
+        await get_zoom_link_and_send_for_course(context)
 
 
 async def get_active_courses_and_prompt_to_get_pro(context: ContextTypes.DEFAULT_TYPE):
     notifications_logger.info(f"triggered get_active_courses_and_prompt_to_get_pro")
 
-    active_courses_today: list[models.Course] = get_active_courses_today()
+    active_courses_today: list[tuple[models.Course, models.CourseNotification]] = get_active_courses_today()
     for course, notification in active_courses_today:
         if notification.send_patreon_reminder:
             context.job.data = {"course_id": course.id}
@@ -260,19 +261,19 @@ async def get_active_courses_and_prompt_to_get_pro(context: ContextTypes.DEFAULT
 # every day the job checks for active courses with today's day of the week
 # and send a notification at 17:53 Berlin time.
 # No need to restart when changing the set of active courses
-async def register_daily_notification_for_active_courses(app):
+async def register_daily_send_zoom_for_active_courses(app):
     app.job_queue.run_daily(
-        callback=get_active_courses_and_handle_notification,
+        callback=get_active_courses_and_send_zoom,
         time=datetime.time(hour=17, minute=53, tzinfo=berlin_tz),
-        name=f"get_active_course_and_send_notification_1753",
+        name=f"get_active_courses_and_send_zoom_1753",
         data={
             "hour": 18,
         }
     )
     app.job_queue.run_daily(
-        callback=get_active_courses_and_handle_notification,
+        callback=get_active_courses_and_send_zoom,
         time=datetime.time(hour=18, minute=53, tzinfo=berlin_tz),
-        name=f"get_active_course_and_send_notification_1853",
+        name=f"get_active_courses_and_send_zoom_1853",
         data={
             "hour": 19,
         }

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -67,6 +67,8 @@ async def handle_leetcode_reminder(context: ContextTypes.DEFAULT_TYPE):
 
 async def handle_send_zoom(context: ContextTypes.DEFAULT_TYPE):
     course_id: int = context.job.data["course_id"]
+    is_zoom_link_only_to_pro: bool = context.job.data["is_zoom_link_only_to_pro"]
+
     if "message" not in context.job.data:
         admin_chat_id = int(os.getenv('ADMIN_CHAT_ID'))
         notifications_logger.error(
@@ -85,18 +87,18 @@ async def handle_send_zoom(context: ContextTypes.DEFAULT_TYPE):
     notifications_logger.debug(f"handling {constants.id_to_course[course_id]} notification, "
                                f"got {len(notification_chat_ids)} chat ids that are subscribed to the course")
 
-    if course_handlers.is_course_pro(course_id):
+    if is_zoom_link_only_to_pro:
         notification_chat_ids = [tg_id for tg_id in notification_chat_ids
                                  if membership.get_user_membership_info(tg_id).get_overall_level() == membership.pro]
         notifications_logger.debug(f"handling {constants.id_to_course[course_id]} notification, "
                                    f"got {len(notification_chat_ids)} PRO subscribers")
     else:
-        notifications_logger.debug(f"Sending a link to everyone because course {course_id} is NOT Pro")
+        notifications_logger.debug(f"Sending a link to everyone because is_zoom_link_only_to_pro for {course_id} is False")
 
     await notifications_helpers.do_send_notifications(context, notification_chat_ids, message, menu,
                                                       constants.id_to_course[course_id])
     await notifications_helpers.email_notifications(context, notification_chat_ids, message, menu,
-                                                      constants.id_to_course[course_id])
+                                                    constants.id_to_course[course_id])
 
 
 async def handle_aoc_notification(context: ContextTypes.DEFAULT_TYPE):
@@ -242,7 +244,7 @@ async def get_active_courses_and_send_zoom(context: ContextTypes.DEFAULT_TYPE):
     active_courses_today: list[tuple[models.Course, models.CourseNotification]] = (
         get_active_courses_today(context.job.data["hour"]))
     for course, notification in active_courses_today:
-        context.job.data = {"course_id": course.id}
+        context.job.data = {"course_id": course.id, "is_zoom_link_only_to_pro": notification.is_zoom_link_only_to_pro}
         await get_zoom_link_and_send_for_course(context)
 
 


### PR DESCRIPTION
# User-visible changes
 - None

# Deployment changes
 - drop `hour` and `day_of_week` in `Course` table
 - use `is_zoom_link_only_to_pro` from `CourseNotification` to decide to whom to send Zoom link