### PR TITLE
report user Zoom attendance per course

### DIFF
--- a/models.py
+++ b/models.py
@@ -108,6 +108,10 @@ class ScheduledPartMessages(Base):
         sqlalchemy.UniqueConstraint('week_number', 'course_id', name='Unique_message_per_week_and_course'),
     )
 
+    def __repr__(self):
+        return f"ScheduledPartMessages({self.week_number=}, {self.course_id=}, {self.text=})"
+
+
 
 class MockSignUp(Base):
     __tablename__ = 'MockSignUp'

--- a/monitoring/calculate_metrics_and_report.py
+++ b/monitoring/calculate_metrics_and_report.py
@@ -7,6 +7,7 @@ from sqlalchemy import distinct, func
 from sqlalchemy.orm import Session
 from telegram import Bot
 from membership import fetch_boosty_patrons, fetch_patrons, membership
+from monitoring.zoom_attendance import set_zoom_attendance_for_active_courses
 
 import models
 import settings
@@ -184,6 +185,7 @@ async def calculate_metrics_and_report(bot: Bot = None) -> None:
         set_enrolled_users_map()
         set_enrolled_users_paid_map()
         set_enrolled_users_activity_membership_map()
+        set_zoom_attendance_for_active_courses(metrics)
 
         metrics.push()
         logger.info("Metrics successfully pushed")

--- a/monitoring/push_monitoring.py
+++ b/monitoring/push_monitoring.py
@@ -56,6 +56,11 @@ class MetricsPusher:
                 ['course'],
                 registry=self.registry
             ),
+            "zoom_attendance": Gauge(
+                'zoom_attendance',
+                'Users on a Zoom call',
+                ['course'],
+                registry=self.registry),
             "activity_members": Gauge(
                 'activity_members',
                 'Users with membership by activity',

--- a/monitoring/zoom_attendance.py
+++ b/monitoring/zoom_attendance.py
@@ -1,0 +1,118 @@
+import base64
+import logging
+import os
+from datetime import date, datetime
+
+import requests
+from dotenv import load_dotenv
+from sqlalchemy.orm import Session
+
+import models
+from monitoring.push_monitoring import MetricsPusher
+
+logger = logging.getLogger("metrics_reporter")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()  # prints to stdout (captured by cron log)
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+load_dotenv()
+
+ACCOUNT_ID = os.getenv("ZOOM_ACCOUNT_ID")
+CLIENT_ID = os.getenv("ZOOM_CLIENT_ID")
+CLIENT_SECRET = os.getenv("ZOOM_CLIENT_SECRET")
+CLIENT_EMAIL = os.getenv("ZOOM_CLIENT_EMAIL")
+
+
+def get_zoom_access_token():
+    url = "https://zoom.us/oauth/token?grant_type=account_credentials&account_id=" + ACCOUNT_ID
+
+    credentials = f"{CLIENT_ID}:{CLIENT_SECRET}"
+    encoded_credentials = base64.b64encode(credentials.encode()).decode()
+
+    headers = {
+        "Authorization": f"Basic {encoded_credentials}"
+    }
+
+    response = requests.post(url, headers=headers)
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+
+def get_meeting_id_from_link(zoom_link: str) -> str:
+    logger.info(f"extracting meeting id from {zoom_link}")
+    items = zoom_link.split('/')
+    params_str = items[4]
+    params = params_str.split('?')
+
+    logger.info(f"meeting id is {params[0]}")
+    return params[0]
+
+
+def get_participant_count(zoom_meeting_id: str) -> int | None:
+    access_token = get_zoom_access_token()
+
+    response = requests.get(
+        f"https://api.zoom.us/v2/report/meetings/{zoom_meeting_id}",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+        },
+        timeout=30,
+    )
+
+    if response.status_code == 404:
+        logger.info(f"No meeting found, returning None instead of participants_count")
+        return None
+
+    response.raise_for_status()
+    data = response.json()
+    logger.info(f"{data=}")
+
+    participants_count = response.json()["participants_count"]
+    logger.info(f"{participants_count=}")
+    return participants_count
+
+
+def set_zoom_attendance_for_active_courses(metrics_pusher: MetricsPusher) -> None:
+    # in app.job_queue.run_daily 0 = Sunday, so in db 0 = Sunday, 1 = Monday
+    # but for datetime 0 = Monday
+    today_weekday: int = (datetime.now().weekday() + 1) % 7
+
+    with Session(models.engine) as session:
+        active_notifications_today = (
+            session.query(
+                models.Course,
+                models.CourseNotification,
+            )
+            .join(models.Course, models.Course.id == models.CourseNotification.course_id)
+            .filter((models.Course.is_active.is_(True)) & (models.CourseNotification.day_of_week == today_weekday))
+            .all()
+        )
+        logger.info(f"{active_notifications_today=}")
+
+        active_course_names_by_id = {
+            course.id: course.name for course,  notification in active_notifications_today
+        }
+        logger.info(f"{active_course_names_by_id=}")
+
+        scheduled_messages = (
+            session.query(models.ScheduledPartMessages)
+            .filter(
+                models.ScheduledPartMessages.week_number == date.today().isocalendar().week,
+                models.ScheduledPartMessages.course_id.in_(active_course_names_by_id),
+            )
+            .all()
+        )
+        logger.info(f"{scheduled_messages=}")
+
+    for scheduled_msg in scheduled_messages:
+        zoom_meeting_id = get_meeting_id_from_link(scheduled_msg.text)
+        participant_count = get_participant_count(zoom_meeting_id)
+        if participant_count:
+            metrics_pusher.set(
+                "zoom_attendance",
+                participant_count,
+                course=active_course_names_by_id[scheduled_msg.course_id]
+            )


### PR DESCRIPTION
# User-visible changes
 - None

# Deployment changes
 - new metrics `zoom_attendance` per course. Takes active courses with notification today, takes a zoom link from `ScheduledPartMessage`, parses meeting id and gets a report about this meeting from Zoom. Will run as part of cron job every day. So for some meetings id there's no report because the meeting haven't happened yet, ignore those meetings.