### PR TITLE
Create a thank_you certificate by command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 auth.json
 google_calendar.auth.json
 data
+latex/images
 
 #pickle persistance for conversation handlers
 nelenkin_bot_pickle

--- a/certificates/create_certificates.py
+++ b/certificates/create_certificates.py
@@ -1,0 +1,35 @@
+import logging
+import subprocess
+from _datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def get_today_date_str() -> tuple[str, str]:
+    months = [
+        "ЯНВАРЯ", "ФЕВРАЛЯ", "МАРТА", "АПРЕЛЯ", "МАЯ", "ИЮНЯ",
+        "ИЮЛЯ", "АВГУСТА", "СЕНТЯБРЯ", "ОКТЯБРЯ", "НОЯБРЯ", "ДЕКАБРЯ"
+    ]
+
+    berlin_tz = ZoneInfo("Europe/Berlin")
+    date = datetime.now(berlin_tz)
+
+    return f"{date.day} {months[date.month - 1]}", f"{date.year} года"
+
+
+async def create_certificates(name: str, tag: str) -> str:
+    logging.info(f"Generating thank you certificate for {name} {tag}")
+
+    date_str, year_str = get_today_date_str()
+
+    with open(f"/tmp/latex/thank_you_{tag}.tex", "w", encoding="utf-8") as f:
+        f.write(
+            rf"\newcommand{{\Recipient}}{{{name} @{tag}}}" "\n"
+            rf"\newcommand{{\DateDay}}{{{date_str}}}" "\n"
+            rf"\newcommand{{\DateYear}}{{{year_str}}}" "\n"
+            r"\input{./thank_you.tex}"
+        )
+
+    subprocess.run(["docker", "exec", "latex", "latexmk", "-pdf",
+                    "-output-directory=/tmp/latex", f"-jobname=thank_you_{tag}", f"/tmp/latex/thank_you_{tag}.tex"],
+                   check=True)
+    return f"thank_you_{tag}.pdf"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,5 +20,15 @@ services:
     ports:
       - 127.0.0.1:6379:6379
 
+  latex:
+    image: texlive/texlive@sha256:ee8ecc627897eabeb42d862d8187546483455e66ce94aa5c2bce1b45a977ab27
+    container_name: latex
+    working_dir: /latex
+    volumes:
+      - ./latex:/latex
+      - /tmp/latex:/tmp/latex
+    command: sleep infinity
+    restart: unless-stopped
+
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,5 +38,15 @@ services:
     depends_on:
       - redis
 
+  latex:
+    image: texlive/texlive@sha256:ee8ecc627897eabeb42d862d8187546483455e66ce94aa5c2bce1b45a977ab27
+    container_name: latex
+    working_dir: /latex
+    volumes:
+      - ./latex:/latex
+      - /tmp/latex:/tmp/latex
+    command: sleep infinity
+    restart: unless-stopped
+
 volumes:
   pgdata:

--- a/handlers/admin_commands.py
+++ b/handlers/admin_commands.py
@@ -15,6 +15,7 @@ from courses import course_helpers
 import helpers
 import models
 import settings
+from certificates import create_certificates
 from monitoring import push_monitoring, update_users_in_db
 from membership import fetch_patrons, fetch_boosty_patrons, membership, update_membership
 
@@ -706,6 +707,26 @@ course_get_users_conv_handler = ConversationHandler(
         CommandHandler("cancel", cancel_get_users),
     ],
 )
+
+
+@is_admin
+async def create_certificate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logging.info(f"create_certificate handler triggered by {helpers.repr_user_from_update(update)}")
+
+    args = context.args
+    if len(args) != 2:
+        await update.message.reply_text("Usage: /create_certificate <name> <tag>")
+        return
+
+    name: str = args[0]
+    tag: str = args[1]
+
+    output_file: str = await create_certificates.create_certificates(name, tag)
+    with open(f"/tmp/latex/{output_file}", "rb") as thank_you_file:
+        await context.bot.send_document(
+            chat_id=settings.ADMIN_CHAT_ID,
+            document=thank_you_file,
+        )
 
 
 @is_admin

--- a/latex/thank_you.tex
+++ b/latex/thank_you.tex
@@ -1,0 +1,126 @@
+\documentclass[12pt]{article}
+
+\usepackage[a4paper,landscape,margin=0pt]{geometry}
+\usepackage{tikz}
+\usepackage[utf8]{inputenc}
+\usepackage[T2A]{fontenc}
+\usepackage[russian]{babel}
+\usepackage{xcolor}
+\usepackage{graphicx}
+\usepackage{microtype}
+
+\pagestyle{empty}
+
+% Colors
+\definecolor{navy}{RGB}{35,54,67}
+\definecolor{gold}{RGB}{190,140,65}
+
+% Recipient is missing! The Recipient should be inserted for the template to work!
+%\newcommand{\Recipient}{Участик @участник}
+
+%DateDay and DateYear also are filled in a wrapper
+%\newcommand{\DateDay}{12 АВГУСТА}
+%\newcommand{\DateYear}{2026}
+
+\newcommand{\Course}{Designing Data-Intensive Applications-5}
+%\newcommand{\Curator}{Куратор @Куратор}
+%\newcommand{\CuratorCourse}{DDIA-5}
+\newcommand{\Author}{Лена Анюшева}
+\newcommand{\AuthorHandle}{T.ME/LENKA\_NE\_CLUB}
+% --------------------------------------
+
+\begin{document}
+
+\begin{tikzpicture}[remember picture,overlay]
+
+% Outer gold frame
+\draw[gold,line width=0.8mm]
+  ([xshift=1.27cm,yshift=-1.42cm]current page.north west)
+  rectangle
+  ([xshift=-1.27cm,yshift=1.42cm]current page.south east);
+
+% Outer gold frame
+\draw[gold,line width=0.8mm]
+  ([xshift=1.52cm,yshift=-1.7cm]current page.north west)
+  rectangle
+  ([xshift=-1.52cm,yshift=1.7cm]current page.south east);
+
+
+% Main title
+\node[
+  anchor=north,
+  font=\sffamily\fontsize{49}{54}\selectfont
+] at ([xshift=14.85cm,yshift=-4.35cm]current page.north west)
+{БЛАГОДАРНОСТЬ};
+
+% Subtitle
+\node[
+  anchor=north,
+  font=\sffamily\fontsize{18}{22}\selectfont
+] at ([xshift=14.85cm,yshift=-6.85cm]current page.north west)
+{объявляется};
+
+% Recipient
+% Uses a large italic serif font so this works with pdfLaTeX.
+\node[
+  anchor=north,
+  font=\rmfamily\itshape\fontsize{38}{43}\selectfont
+] at ([xshift=14.85cm,yshift=-8.05cm]current page.north west)
+{\Recipient};
+
+% Description
+\node[
+  anchor=north,
+  font=\sffamily\fontsize{17}{21}\selectfont
+] at ([xshift=14.85cm,yshift=-10.65cm]current page.north west)
+{за презентацию для потока};
+
+% Course
+\node[
+  anchor=north,
+  font=\sffamily\fontsize{25}{29}\selectfont
+] at ([xshift=14.85cm,yshift=-11.48cm]current page.north west)
+{\Course};
+
+% Author
+\node[
+  anchor=north,
+  font=\sffamily\fontsize{17}{20}\selectfont
+] at ([xshift=5.50cm,yshift=-15.88cm]current page.north west)
+{\Author};
+
+% Signature
+\node[
+  anchor=north,
+  inner sep=0pt
+] at ([xshift=5.70cm,yshift=-14.55cm]current page.north west)
+{\includegraphics[width=3.5cm]{/latex/images/lena_signature.png}};
+
+% Author handle
+\node[
+  anchor=north,
+  font=\sffamily\fontsize{15}{18}\selectfont
+] at ([xshift=5.50cm,yshift=-16.68cm]current page.north west)
+{\AuthorHandle};
+
+% Date
+\node[
+  anchor=north,
+  align=center,
+  font=\rmfamily\fontsize{13}{16}\selectfont
+] at ([xshift=14.85cm,yshift=-16cm]current page.north west)
+{\DateDay\\[1mm]\DateYear};
+
+%% Curator
+%\node[
+%  anchor=north,
+%  align=center,
+%  font=\sffamily\fontsize{15}{18}\selectfont
+%] at ([xshift=23.25cm,yshift=-15.88cm]current page.north west)
+%{\Curator\\
+% КУРАТОР ПОТОКА\\
+% \CuratorCourse};
+
+\end{tikzpicture}
+
+\end{document}

--- a/main.py
+++ b/main.py
@@ -46,6 +46,9 @@ if __name__ == '__main__':
     application.add_handler(admin_commands.course_broadcast_basic_conv_handler)
     application.add_handler(admin_commands.course_get_users_conv_handler)
     application.add_handler(admin_commands.leetcode_new_topic_broadcast)
+    application.add_handler(
+        CommandHandler('create_certificate', admin_commands.create_certificate,
+                       filters.ChatType.PRIVATE))
     application.add_handler(leetcode_mock_handlers.leetcode_register_handler)
     application.add_handler(intro_handler.intro_conv_handler)
     application.add_handler(patreon_handlers.connect_patreon_handler)


### PR DESCRIPTION
# User-visible changes
 ## Admin API
  - `/create_certificate <name> <tag>` for admin to create a signed thank you certificate
 
# Deployment changes
 - latex log are printed to `/tmp/latex`, which should be cleaned from time to time
 - image for a signature needs to be uploaded on the server

This is for https://github.com/LenaAn/neLenkin_bot/issues/246, but also
# Future work is needed:
 - also admin should be able to choose for which stream the certificate is for
 - ideally the certificate is forwarded to the discussion thread for this stream automatically