### PR TITLE
add a year to leetcode mocks signups

### DIFF
--- a/alembic/versions/f7c1e3515877_add_year_to_mock_sign_ups.py
+++ b/alembic/versions/f7c1e3515877_add_year_to_mock_sign_ups.py
@@ -1,0 +1,33 @@
+"""add year to mock sign ups
+
+Revision ID: f7c1e3515877
+Revises: a25d459f4fa3
+Create Date: 2026-08-23 23:50:50.440933
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f7c1e3515877'
+down_revision: Union[str, Sequence[str], None] = 'a25d459f4fa3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('MockSignUp', sa.Column('year', sa.Integer(), nullable=True))
+    op.drop_constraint(op.f('One_record_per_user_per_week'), 'MockSignUp', type_='unique')
+    op.create_unique_constraint('One_record_per_user_per_week', 'MockSignUp', ['week_number', 'tg_id', 'year'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('One_record_per_user_per_week', 'MockSignUp', type_='unique')
+    op.create_unique_constraint(op.f('One_record_per_user_per_week'), 'MockSignUp', ['week_number', 'tg_id'],
+                                postgresql_nulls_not_distinct=False)
+    op.drop_column('MockSignUp', 'year')

--- a/handlers/leetcode_mock_handlers.py
+++ b/handlers/leetcode_mock_handlers.py
@@ -168,6 +168,7 @@ async def leetcode_english(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     with Session(models.engine) as session:
         mock_signup = {
             "week_number": datetime.date.today().isocalendar().week,
+            "year": datetime.date.today().isocalendar().year,
             "tg_username": helpers.get_user(update).username,
             "tg_id": helpers.get_user(update).id,
             "first_problem": context.user_data['first_problem'],
@@ -235,7 +236,8 @@ async def cancel_leetcode_register(update: Update, context: ContextTypes.DEFAULT
             delete(models.MockSignUp)
             .where(
                 models.MockSignUp.tg_id == str(helpers.get_user(update).id),
-                models.MockSignUp.week_number == datetime.date.today().isocalendar().week
+                models.MockSignUp.week_number == datetime.date.today().isocalendar().week,
+                models.MockSignUp.year == datetime.date.today().isocalendar().year,
             )
         )
         session.execute(stmt)

--- a/leetcode_pairs/generate_graph.py
+++ b/leetcode_pairs/generate_graph.py
@@ -19,8 +19,9 @@ class Pair:
 
 
 class GenerateLeetcodeMocks:
-    def __init__(self, week_number):
+    def __init__(self, week_number, year):
         self.week_number = datetime.date.today().isocalendar().week if week_number is None else week_number
+        self.year = datetime.date.today().isocalendar().year if year is None else year
         self.sign_ups: list[models.MockSignUp] = []  # load only for this week
         self.users: list[models.User] = []  # load only those who enrolled this week
         self.pairs: list[Pair] = []
@@ -40,10 +41,11 @@ class GenerateLeetcodeMocks:
     def load_sign_ups(self):
         with (Session(models.engine) as session):
             mocks_signups = session.query(models.MockSignUp) \
-                .filter(models.MockSignUp.week_number == self.week_number).all()
-            leetcode_pairs_logger.info(f"got mock signups for week {self.week_number}: {mocks_signups}")
+                .filter((models.MockSignUp.week_number == self.week_number) &
+                        (models.MockSignUp.year == self.year)).all()
+            leetcode_pairs_logger.info(f"got mock signups for week {self.week_number} {self.year}: {mocks_signups}")
             self.sign_ups = mocks_signups
-            leetcode_pairs_logger.info(f"self.sign_ups for week {self.week_number}: {self.sign_ups}")
+            leetcode_pairs_logger.info(f"self.sign_ups for week {self.week_number} {self.year}: {self.sign_ups}")
 
     def load_users_for_signed_up_users(self):
         tg_ids = [signup.tg_id for signup in self.sign_ups]
@@ -52,7 +54,7 @@ class GenerateLeetcodeMocks:
                 .filter(models.User.tg_id.in_(tg_ids)).all()
             leetcode_pairs_logger.info(f"got Users for signed up users: {users}")
             self.users = users
-            leetcode_pairs_logger.info(f"self.users for week {self.week_number}: {self.users}")
+            leetcode_pairs_logger.info(f"self.users for week {self.week_number} {self.year}: {self.users}")
 
     def generate_input(self) -> tuple[int, set]:
         users_to_timeslots = {}
@@ -110,7 +112,8 @@ class GenerateLeetcodeMocks:
 
     def calculate_pairs(self):
         if len(self.sign_ups) == 0:
-            leetcode_pairs_logger.info(f"no signups this week number {self.week_number}, skipping calculating pairs")
+            leetcode_pairs_logger.info(f"no signups this week number {self.week_number} {self.year}, "
+                                       f"skipping calculating pairs")
             return
         hypothetical_number_of_users, graph = self.generate_input()
 
@@ -130,8 +133,8 @@ class GenerateLeetcodeMocks:
                 f.write(f"{pair.first.id} {pair.second.id}\n")
 
     @classmethod
-    def build(cls, week_number=None):
-        obj = cls(week_number)
+    def build(cls, week_number=None, year=None):
+        obj = cls(week_number, year)
         obj.load_sign_ups()
         obj.load_users_for_signed_up_users()
         obj.calculate_pairs()

--- a/leetcode_pairs/leetcode_notifications.py
+++ b/leetcode_pairs/leetcode_notifications.py
@@ -98,7 +98,7 @@ async def leetcode_notifications(context: ContextTypes.DEFAULT_TYPE):
         return
 
     generate_graph_obj = generate_graph.GenerateLeetcodeMocks.build(
-        week_number=datetime.date.today().isocalendar().week)
+        week_number=datetime.date.today().isocalendar().week, year=datetime.datetime.today().isocalendar().year)
 
     await send_leetcode_pairs_to_group(context, generate_graph_obj)
     await unicast_leetcode_partner(context, generate_graph_obj)

--- a/models.py
+++ b/models.py
@@ -131,9 +131,10 @@ class MockSignUp(Base):
     selected_timeslots = Column(sqlalchemy.JSON, nullable=False)
     programming_language = Column(sqlalchemy.Text, nullable=False)
     english_choice = Column(sqlalchemy.Boolean, nullable=False)
+    year = Column(sqlalchemy.Integer, nullable=True)
 
     __table_args__ = (
-        sqlalchemy.UniqueConstraint('week_number', 'tg_id', name='One_record_per_user_per_week'),
+        sqlalchemy.UniqueConstraint('week_number', 'tg_id', 'year', name='One_record_per_user_per_week'),
     )
 
     def __repr__(self):


### PR DESCRIPTION
# User-visible changes
 - no more unexpected pairs

# Deployment changes
 - new alembic migration
 - need to backfill year to existing records